### PR TITLE
Patchsets live

### DIFF
--- a/tigerr/tigerr.kv
+++ b/tigerr/tigerr.kv
@@ -32,6 +32,7 @@
     cols: 1
     rows: 3
     queries: queries
+    patchsets: patchsets
     # TODO:
     cache_size: 0
     BoxLayout:
@@ -119,9 +120,10 @@
             PanelHeader:
                 text: 'Patchsets'
             Label:
+                size_hint: (None, None)
+                height: dp(10)
                 text: ''
             RecycleView:
-                # TODO
                 id: patchsets
                 scroll_type: ['bars', 'content']
                 scroll_wheel_distance: dp(124)

--- a/tigerr/widgets/patchsetrow.kv
+++ b/tigerr/widgets/patchsetrow.kv
@@ -7,15 +7,30 @@
         Rectangle:
             size: self.size
             pos: self.pos
-    subject: 'TODO'
+    subject: ''
+    owned_by: ''
+    createdOnStr: ''
+    lastUpdatedStr: ''
     GridLayout:
         cols: 2
         rows: 2
         Button:
             text: root.subject
-        Label:
-            text: '1'
-        Label:
-            text: '2'
-        Label:
-            text: '3'
+            shorten: True
+            font_size: dp(12)
+            text_size: self.size
+            font_name: 'fonts/Vera-Bold.ttf'
+            bold: True
+        PSLabel:
+            text: root.owned_by
+        PSLabel:
+            text: 'created on: ' + root.createdOnStr
+        PSLabel:
+            text: 'last update: ' + root.lastUpdatedStr
+
+<PSLabel@Label>:
+    text: ''
+    font_size: dp(10)
+    text_size: self.size
+    font_name: 'fonts/Vera.ttf'
+


### PR DESCRIPTION
Patchsets are currently just accumulating rather than
updating as one might expect, so don't leave this running
more than a minute or two, and clear the .patchsets.p file.

TODOs:
- sort by CR wait time
- update patchsets rather than accumulating forever
- paginating needs implemented
- hide patchsets when toggled a query button
- display query toggle button image properly
- Need some first-run config popup
- Need query test popup